### PR TITLE
Fix lobby join interaction timeout handling

### DIFF
--- a/modules/lobby/lobby.py
+++ b/modules/lobby/lobby.py
@@ -69,34 +69,39 @@ class JoinLobbyButton(View):
 
     @discord.ui.button(label="Присоединиться к лобби", style=discord.ButtonStyle.success)
     async def join_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        # Сразу подтверждаем интеракцию, чтобы Discord не вернул "Unknown interaction"
+        # если загрузка профиля/ранга займёт больше ~3 секунд.
+        try:
+            await interaction.response.defer(ephemeral=True)
+        except discord.InteractionResponded:
+            pass
+
         # Берём профиль из кэша (внутри ensure_fresh_rank → Django + HenrikDev)
         try:
-            profile = await asyncio.wait_for(profiles_cache.get(interaction.user.id), timeout=2.0)
-        except asyncio.TimeoutError:
-            logger.warning(
-                f"⚠ join_button timeout while loading profile for {interaction.user.id}"
+            profile = await profiles_cache.get(interaction.user.id)
+        except Exception as e:
+            logger.warning(f"⚠ join_button failed while loading profile for {interaction.user.id}: {e}")
+            await interaction.followup.send(
+                "⚠ Сервис профилей временно недоступен. Попробуйте ещё раз через пару секунд.",
+                ephemeral=True,
             )
-            if not interaction.response.is_done():
-                await interaction.response.send_message(
-                    "⚠ Сервис профилей временно недоступен. Попробуйте ещё раз через пару секунд.",
-                    ephemeral=True,
-                )
-            else:
-                await interaction.followup.send(
-                    "⚠ Сервис профилей временно недоступен. Попробуйте ещё раз через пару секунд.",
-                    ephemeral=True,
-                )
             return
 
         # 1) Профиля нет или не заполнен Riot ID → ОДИН раз показываем модалку
         username = (profile or {}).get("username") if profile else ""
         if not (username or "").strip():
-            await interaction.response.send_modal(PlayerProfileModal(interaction, lobby=self.lobby))
+            await interaction.followup.send(
+                "⚠ У вас не заполнен Riot ID. Используйте /profile, чтобы указать его в формате Name#TAG.",
+                ephemeral=True,
+            )
             return
 
         # 2) Кривой формат Riot ID (нет # и т.п.) → даём пользователю поправить
         if not riot_id_is_valid(username):
-            await interaction.response.send_modal(PlayerProfileModal(interaction, lobby=self.lobby))
+            await interaction.followup.send(
+                "⚠ Riot ID указан в неверном формате. Используйте /profile и введите Name#TAG.",
+                ephemeral=True,
+            )
             return
 
         # 3) Пустой ранг — считаем его Unranked, но не мучаем модалкой
@@ -114,11 +119,6 @@ class JoinLobbyButton(View):
                 logger.warning(f"Не удалось автоматически выставить Unranked для {interaction.user.id}: {e}")
 
         # 4) Дальше — твоя текущая логика проверки бана и добавления в лобби
-        try:
-            await interaction.response.defer(ephemeral=True)
-        except discord.InteractionResponded:
-            pass  # если уже ответили (редкий случай)
-
         ban = await is_banned(interaction.user.id)
         if ban.get("banned"):
             text = render_ban_message(


### PR DESCRIPTION
### Motivation
- Prevent `404 Unknown interaction` and cancelled tasks when external rank/profile lookups take longer than Discord's interaction window. 
- Improve UX by reliably acknowledging interactions before performing potentially slow I/O (HenrikDev / Django API). 

### Description
- Updated `modules/lobby/lobby.py` to call `await interaction.response.defer(ephemeral=True)` at the start of `JoinLobbyButton.join_button` so interactions are acknowledged immediately. 
- Removed the strict `asyncio.wait_for(..., timeout=2.0)` around profile loading and replaced it with a normal `profiles_cache.get(...)` call plus broader exception handling to avoid `CancelledError`. 
- Converted immediate modal sends to safe follow-up messages after deferring, replacing `send_modal`/`response.send_message` in invalid/missing Riot ID cases with `interaction.followup.send(...)` that instructs the user to use `/profile`. 
- Kept existing ban checks, add-member logic and message-update flow, and adjusted error responses to use followups where appropriate to avoid `Unknown interaction` errors. 

### Testing
- Ran bytecode compilation with `python -m compileall modules`, which completed successfully. 
- Ran test discovery with `pytest -q`, which reported `no tests ran` (repository has no automated tests to execute).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb7fbb8fc832faba32256d46c1043)